### PR TITLE
(chore): [Release] v5.0.0+50000015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LunaSea Changelog
 
-## GitHub
+## v5.0.0 (50000015)
 
 #### NEW
 - `[Radarr/Queue]` Ability to view and manage the queue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### NEW
 - `[Radarr/Queue]` Ability to view and manage the queue
-- `[Radarr/System Status]` Show root folders on the disk space page
+- `[Radarr/Status]` Show root folders on the disk space page
 
 #### TWEAKS
 - `[UI/UX]` Highlight active profile in profile switcher popup menus
@@ -14,16 +14,17 @@
 - `[UI/UX]` Search and filter/sort buttons now have fixed heights to have consistency across platforms
 - `[UI/UX]` Show click cursor on all clickable tiles
 - `[UI/UX]` Show two buttons per line on expandable tiles
+- `[UI/UX]` Clear button would not always appear on input bars
 
 #### PLATFORM SPECIFIC
 - `[macOS]` (new) Added LunaSea icon
-- `[macOS]` (new) Enabled notification support
-- `[macOS]` (new) Enable hardening runtime and set development signing certificate
+- `[macOS]` (fix) Added platform compatability checks for all native linking packages
+- `[macOS]` (new) Added notification support
+- `[macOS]` (new) Added hardening runtime and set development signing certificate
 - `[macOS]` (tweak) Set minimum macOS version to 10.14 (Mojave)
 - `[macOS]` (fix) Set minimum window size to prevent reactive overflow issues
 - `[macOS]` (fix) Updated about dialog to have correct information
 - `[macOS]` (fix) Set application/window title
-- `[macOS]` (fix) Add platform compatability checks for all native linking packages
 - `[macOS]` (fix) Utilize package_info_plus to allow internal version checking
 - `[macOS]` (fix) Hide incompatible settings options
 

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,6 +1,59 @@
 {
-    "motd": "",
-    "new": [],
-    "tweaks": [],
-    "fixes": []
+    "motd": "This build introduces the last major feature of Radarr, the queue! You can now view and manage your queue, including triggering a manual import when necessary.\n\nThis build also introduces the first public-alpha release of the native macOS client, you can read more about it and download the release on Reddit or Discord!",
+    "new": [
+        {
+            "module": "Radarr/\nQueue",
+            "changes": [
+                "Ability to view and manage the queue"
+            ]
+        },
+        {
+            "module": "Radarr/\nStatus",
+            "changes": [
+                "Show root folders on the disk space page"
+            ]
+        }
+    ],
+    "tweaks": [
+        {
+            "module": "UI/UX",
+            "changes": [
+                "Highlight active profile in profile switcher popup menus"
+            ]
+        }
+    ],
+    "fixes": [
+        {
+            "module": "Radarr/\nCatalogue",
+            "changes": [
+                "Update filters to more closely match the web GUI filtering"
+            ]
+        },
+        {
+            "module": "UI/UX",
+            "changes": [
+                "Search and filter/sort buttons now have fixed heights to have consistency across platforms",
+                "Show click cursor on all clickable tiles",
+                "Show two buttons per line on expandable tiles",
+                "Clear button would not always appear on input bars"
+            ]
+        }
+    ],
+    "platform": [
+        {
+            "module": "macOS",
+            "changes": [
+                "Added LunaSea icon",
+                "Added platform compatability checks for all native linking packages",
+                "Added notification support",
+                "Added hardening runtime and set development signing certificate",
+                "Set minimum macOS version to 10.14 (Mojave)",
+                "Set minimum window size to prevent reactive overflow issues",
+                "Set application/window title",
+                "Updated about dialog to have correct information",
+                "Utilize package_info_plus to allow internal version checking",
+                "Hide incompatible settings options"
+            ]
+        }
+    ]
 }

--- a/lib/core/ui/input_bar.dart
+++ b/lib/core/ui/input_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:lunasea/core.dart';
 
 class LunaTextInputBar extends StatefulWidget {
@@ -48,6 +49,22 @@ class _State extends State<LunaTextInputBar> {
     bool _isFocused = false;
 
     @override
+    void initState() {
+        super.initState();
+        widget.controller?.addListener(_controllerListener);
+    }
+
+    @override
+    void dispose() {
+        widget.controller?.removeListener(_controllerListener);
+        super.dispose();
+    }
+
+    void _controllerListener() {
+        if(mounted) setState(() {});
+    }
+
+    @override
     Widget build(BuildContext context) => LunaCard(
         context: context,
         margin: widget.margin,
@@ -74,17 +91,20 @@ class _State extends State<LunaTextInputBar> {
             fontSize: LunaUI.FONT_SIZE_SUBTITLE,
         ),
         suffixIcon: AnimatedOpacity(
-            child: GestureDetector(
+            child: InkWell(
                 child: Icon(
                     Icons.close,
                     color: LunaColours.accent,
                     size: 24.0,
                 ),
-                onTap: widget.onChanged == null ? null : () {
+                onTap: !_isFocused || widget.controller.text == '' ? null : () {
                     widget.scrollController?.lunaAnimateToStart();
                     widget.controller.text = '';
-                    widget.onChanged('');
-                }
+                    if(widget.onChanged != null) widget.onChanged('');
+                },
+                mouseCursor: !_isFocused || widget.controller.text == '' ? SystemMouseCursors.text : SystemMouseCursors.click,
+                borderRadius: BorderRadius.circular(24.0),
+                hoverColor: Colors.transparent,
             ),
             opacity: !_isFocused || widget.controller.text == '' ? 0.0 : 1.0,
             duration: Duration(milliseconds: 200),

--- a/lib/core/utilities/changelog.dart
+++ b/lib/core/utilities/changelog.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -64,6 +65,16 @@ class LunaChangelog {
                                     ),
                                 ),
                             ),
+                            if((changelog.changesPlatform?.length ?? 0) != 0) LunaHeader(text: 'Platform-Specific'),
+                            if((changelog.changesPlatform?.length ?? 0) != 0) LunaTableCard(
+                                content: List<LunaTableContent>.generate(
+                                    changelog.changesPlatform.length,
+                                    (index) => LunaTableContent(
+                                        title: changelog.changesPlatform[index].module,
+                                        body: changelog.changesPlatform[index].changes.fold('', (data, object) => data += '${LunaUI.TEXT_BULLET}\t$object\n').trim(),
+                                    ),
+                                ),
+                            ),
                         ],
                     ),
                     bottomNavigationBar: LunaBottomActionBar(
@@ -91,6 +102,7 @@ class _Changelog {
     List<_Change> changesNew;
     List<_Change> changesTweaks;
     List<_Change> changesFixes;
+    List<_Change> changesPlatform;
 
     static _Changelog fromJson(Map<String, dynamic> json) {
         _Changelog changelog = _Changelog();
@@ -99,6 +111,23 @@ class _Changelog {
         changelog.changesNew = json['new'] == null ? [] : (json['new'] as List).map<_Change>((change) => _Change.fromJson(change)).toList();
         changelog.changesTweaks = json['tweaks'] == null ? [] : (json['tweaks'] as List).map<_Change>((change) => _Change.fromJson(change)).toList();
         changelog.changesFixes = json['fixes'] == null ? [] : (json['fixes'] as List).map<_Change>((change) => _Change.fromJson(change)).toList();
+        // macOS
+        changelog.changesPlatform = [];
+        int _index = -1;
+        _index = (json['platform'] as List).indexWhere((element) => element['module'] == 'macOS');
+        if(Platform.isMacOS &&  json['platform'] != null &&  _index >= 0) changelog.changesPlatform = [
+            _Change.fromJson(json['platform'][_index]),
+        ];
+        // Android
+        _index = (json['platform'] as List).indexWhere((element) => element['module'] == 'Android');
+        if(Platform.isAndroid &&  json['platform'] != null &&  _index >= 0) changelog.changesPlatform = [
+            _Change.fromJson(json['platform'][_index]),
+        ];
+        // iOS
+        _index = (json['platform'] as List).indexWhere((element) => element['module'] == 'iOS');
+        if(Platform.isIOS &&  json['platform'] != null &&  _index >= 0) changelog.changesPlatform = [
+            _Change.fromJson(json['platform'][_index]),
+        ];
         return changelog;
     }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -582,7 +582,7 @@ packages:
       name: in_app_purchase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1+3"
+    version: "0.5.2"
   infinite_scroll_pagination:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lunasea
 description: Self-Hosted Controller
-version: 5.0.0+50000014
+version: 5.0.0+50000015
 publish_to: 'none'
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -32,7 +32,7 @@ dependencies:
   google_nav_bar: ^5.0.3                  # ANDROID IOS LINUX MACOS WEB WINDOWS
   hive: ^2.0.2                            # ANDROID IOS LINUX MACOS WEB WINDOWS
   hive_flutter: ^1.0.0                    # ANDROID IOS LINUX MACOS     WINDOWS
-  in_app_purchase: ^0.5.1+3               # ANDROID IOS
+  in_app_purchase: ^0.5.2                 # ANDROID IOS
   infinite_scroll_pagination: ^3.0.1      # ANDROID IOS LINUX MACOS WEB WINDOWS
   intl: ^0.17.0                           # ANDROID IOS LINUX MACOS WEB WINDOWS
   modal_bottom_sheet: ^2.0.0              # ANDROID IOS LINUX MACOS WEB WINDOWS


### PR DESCRIPTION
#### NEW
- `[Radarr/Queue]` Ability to view and manage the queue
- `[Radarr/Status]` Show root folders on the disk space page

#### TWEAKS
- `[UI/UX]` Highlight active profile in profile switcher popup menus

#### FIXES
- `[Radarr/Catalogue]` Update filters to more closely match the web GUI filtering
- `[UI/UX]` Search and filter/sort buttons now have fixed heights to have consistency across platforms
- `[UI/UX]` Show click cursor on all clickable tiles
- `[UI/UX]` Show two buttons per line on expandable tiles
- `[UI/UX]` Clear button would not always appear on input bars

#### PLATFORM SPECIFIC
- `[macOS]` (new) Added LunaSea icon
- `[macOS]` (fix) Added platform compatability checks for all native linking packages
- `[macOS]` (new) Added notification support
- `[macOS]` (new) Added hardening runtime and set development signing certificate
- `[macOS]` (tweak) Set minimum macOS version to 10.14 (Mojave)
- `[macOS]` (fix) Set minimum window size to prevent reactive overflow issues
- `[macOS]` (fix) Updated about dialog to have correct information
- `[macOS]` (fix) Set application/window title
- `[macOS]` (fix) Utilize package_info_plus to allow internal version checking
- `[macOS]` (fix) Hide incompatible settings options