### PR TITLE
fix(Sharesheet): Ensure the sheet origin is visible on iPadOS, support for macOS

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -200,7 +200,7 @@ PODS:
   - SDWebImage (5.11.0):
     - SDWebImage/Core (= 5.11.0)
   - SDWebImage/Core (5.11.0)
-  - share (0.0.1):
+  - share_plus (0.0.1):
     - Flutter
   - shared_preferences (0.0.1):
     - Flutter
@@ -227,7 +227,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - quick_actions (from `.symlinks/plugins/quick_actions/ios`)
-  - share (from `.symlinks/plugins/share/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
@@ -289,8 +289,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider/ios"
   quick_actions:
     :path: ".symlinks/plugins/quick_actions/ios"
-  share:
-    :path: ".symlinks/plugins/share/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences:
     :path: ".symlinks/plugins/shared_preferences/ios"
   url_launcher:
@@ -338,7 +338,7 @@ SPEC CHECKSUMS:
   quick_actions: 6cb2390c4dab0e737c94573c27e18d9666710720
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SDWebImage: 7acbb57630ac7db4a495547fb73916ff3e432f6b
-  share: 0b2c3e82132f5888bccca3351c504d0003b3b410
+  share_plus: 1210d16d59b24d9fe73c2cbec481758952348b81
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
   SwiftyGif: 5d4af95df24caf1c570dbbcb32a3b8a0763bc6d7
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
 				"${BUILT_PRODUCTS_DIR}/quick_actions/quick_actions.framework",
-				"${BUILT_PRODUCTS_DIR}/share/share.framework",
+				"${BUILT_PRODUCTS_DIR}/share_plus/share_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences/shared_preferences.framework",
 				"${BUILT_PRODUCTS_DIR}/url_launcher/url_launcher.framework",
 			);
@@ -486,7 +486,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/quick_actions.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher.framework",
 			);

--- a/lib/core/system/filesystem.dart
+++ b/lib/core/system/filesystem.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:lunasea/core.dart';
-import 'package:share/share.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
 class LunaFileSystem {

--- a/lib/core/system/filesystem.dart
+++ b/lib/core/system/filesystem.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:path_provider/path_provider.dart';
@@ -9,13 +10,16 @@ class LunaFileSystem {
     /// Temporarily writes the string as a [File] to the temporary storage directory on the OS.
     /// 
     /// Temporary storage is eventually cleared by the OS, but is more than enough time to save/send via the share sheet.
-    Future<void> exportStringToShareSheet(String name, String data) async {
+    Future<void> exportStringToShareSheet(BuildContext context, String name, String data) async {
+        final RenderBox box = context.findRenderObject();
         Directory tempDirectory = await getTemporaryDirectory();
         String path = '${tempDirectory.path}/$name';
         File file = File(path);
         await file?.writeAsString(data);
-        await Share.shareFiles([path])
-        .catchError((error, stack) {
+        await Share.shareFiles(
+            [path],
+            sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
+        ).catchError((error, stack) {
             LunaLogger().error('Failed to share string to sharesheet', error, stack);
         });
     }
@@ -24,11 +28,14 @@ class LunaFileSystem {
     /// 
     /// The path can be anywhere on the OS, but must be accessible by the application or will throw an error.
     /// If the file does not exist, will simply do nothing.
-    Future<void> exportFileToShareSheet(String path) async {
+    Future<void> exportFileToShareSheet(BuildContext context, String path) async {
+        final RenderBox box = context.findRenderObject();
         File file = File(path);
-        if(file.existsSync()) await Share.shareFiles([path])
-        .catchError((error, stack) {
-            LunaLogger().error('Failed to share string to sharesheet', error, stack);
+        if(file.existsSync()) await Share.shareFiles(
+            [path],
+            sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
+        ).catchError((error, stack) {
+            LunaLogger().error('Failed to share file to sharesheet', error, stack);
         });
     }
 }

--- a/lib/modules/search/core/types/download_type.dart
+++ b/lib/modules/search/core/types/download_type.dart
@@ -75,7 +75,7 @@ extension SearchDownloadTypeExtension on SearchDownloadType {
         String cleanTitle = data.title.replaceAll(RegExp(r'[^0-9a-zA-Z. -]+'), '');
         try {
             context.read<SearchState>().api.downloadRelease(data)
-            .then((download) => LunaFileSystem().exportStringToShareSheet('$cleanTitle.nzb', download));
+            .then((download) => LunaFileSystem().exportStringToShareSheet(context, '$cleanTitle.nzb', download));
             
         } catch (error, stack) {
             LunaLogger().error('Error downloading NZB', error, stack);

--- a/lib/modules/settings/routes/system/widgets/backup_tile.dart
+++ b/lib/modules/settings/routes/system/widgets/backup_tile.dart
@@ -22,7 +22,11 @@ class SettingsSystemBackupRestoreBackupTile extends StatelessWidget {
                 String data = LunaConfiguration().export();
                 String encrypted = LunaEncryption().encrypt(_values[1], data);
                 String name = DateFormat('y-MM-dd kk-mm-ss').format(DateTime.now());
-                if(encrypted != LunaEncryption.ENCRYPTION_FAILURE) await LunaFileSystem().exportStringToShareSheet('$name.lunasea', encrypted);
+                if(encrypted != LunaEncryption.ENCRYPTION_FAILURE) await LunaFileSystem().exportStringToShareSheet(
+                    context,
+                    '$name.lunasea',
+                    encrypted,
+                );
             }
         } catch (error, stack) {
             LunaLogger().error('Backup Failed', error, stack);

--- a/lib/modules/settings/routes/system_logs/route.dart
+++ b/lib/modules/settings/routes/system_logs/route.dart
@@ -94,17 +94,19 @@ class _State extends State<_SettingsSystemLogsRoute> with LunaScrollControllerMi
     }
 
     Widget _exportLogs() {
-        return LunaButton.text(
-            text: 'Export',
-            icon: Icons.file_download,
-            onTap: () async {
-                showLunaInfoSnackBar(
-                    title: 'Exporting Logs',
-                    message: 'Please wait...',
-                );
-                File logs = await LunaLogger().exportLogs();
-                LunaFileSystem().exportFileToShareSheet(logs.path);
-            },
+        return Builder(
+            builder: (context) => LunaButton.text(
+                text: 'Export',
+                icon: Icons.file_download,
+                onTap: () async {
+                    showLunaInfoSnackBar(
+                        title: 'Exporting Logs',
+                        message: 'Please wait...',
+                    );
+                    File logs = await LunaLogger().exportLogs();
+                    LunaFileSystem().exportFileToShareSheet(context, logs.path);
+                },
+            ),
         );
     }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import firebase_storage
 import network_info_plus_macos
 import package_info_plus_macos
 import path_provider_macos
+import share_plus_macos
 import shared_preferences_macos
 import url_launcher_macos
 import window_size
@@ -30,6 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FLTPackageInfoPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowSizePlugin.register(with: registry.registrar(forPlugin: "WindowSizePlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -125,6 +125,8 @@ PODS:
     - FlutterMacOS
   - PromisesObjC (1.2.12)
   - Reachability (3.2)
+  - share_plus_macos (0.0.1):
+    - FlutterMacOS
   - shared_preferences_macos (0.0.1):
     - FlutterMacOS
   - url_launcher_macos (0.0.1):
@@ -145,6 +147,7 @@ DEPENDENCIES:
   - network_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/network_info_plus_macos/macos`)
   - package_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos`)
   - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
+  - share_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos`)
   - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_size (from `Flutter/ephemeral/.symlinks/plugins/window_size/macos`)
@@ -193,6 +196,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos
   path_provider_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
+  share_plus_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus_macos/macos
   shared_preferences_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos
   url_launcher_macos:
@@ -233,6 +238,7 @@ SPEC CHECKSUMS:
   path_provider_macos: a0a3fd666cb7cd0448e936fb4abad4052961002b
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
+  share_plus_macos: 853ee48e7dce06b633998ca0735d482dd671ade4
   shared_preferences_macos: 480ce071d0666e37cef23fe6c702293a3d21799e
   url_launcher_macos: 45af3d61de06997666568a7149c1be98b41c95d4
   window_size: 339dafa0b27a95a62a843042038fa6c3c48de195

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,13 +905,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  share:
+  share_plus:
     dependency: "direct main"
     description:
-      name: share
+      name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  share_plus_linux:
+    dependency: transitive
+    description:
+      name: share_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  share_plus_macos:
+    dependency: transitive
+    description:
+      name: share_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  share_plus_web:
+    dependency: transitive
+    description:
+      name: share_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  share_plus_windows:
+    dependency: transitive
+    description:
+      name: share_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   radarr: ^2.1.0                          # ANDROID IOS LINUX MACOS WEB WINDOWS
   # radarr:
   #   path: /Users/jagandeepbrar/Git/Packages/radarr
-  share: ^2.0.1                           # ANDROID IOS
+  share_plus: ^2.0.1                      # ANDROID IOS LINUX MACOS WEB WINDOWS
   sonarr: ^2.0.0                          # ANDROID IOS LINUX MACOS WEB WINDOWS
   stack_trace: ^1.10.0                    # ANDROID IOS LINUX MACOS WEB WINDOWS
   supercharged: ^2.0.0                    # ANDROID IOS LINUX MACOS WEB WINDOWS


### PR DESCRIPTION
Utilize the `share_plus` package instead of `share` to implement macOS and future platform support.

Also ensure that the sheet's origin is set to ensure the sheet is in a visible location on iPadOS devices.

Fixes #314 