### PR TITLE
fix(Filesystem): Utilize native file and folder selection for macOS filesystem functions

### DIFF
--- a/derry.yaml
+++ b/derry.yaml
@@ -16,3 +16,11 @@ blackbox:
   files: blackbox_list_files
   shred: blackbox_shred_all_files
   update: blackbox_update_all_files
+cocoapods:
+  nuke:
+    - rm -rf ~/Library/Caches/CocoaPods
+    - rm -rf macos/Pods
+    - rm -rf ~/Library/Developer/Xcode/DerivedData/*
+    - cd ./macos && pod deintegrate
+    - cd ./macos && pod setup
+    - cd ./macos && pod install

--- a/lib/core/system/filesystem.dart
+++ b/lib/core/system/filesystem.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:file_picker/file_picker.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -7,58 +8,112 @@ import 'package:share_plus/share_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
 class LunaFileSystem {
-    /// Export a given string to the filesystem.
+    /// Export a given byte array to the filesystem.
     /// 
     /// Depending on the platform, uses different methods to export the data:
-    /// - iOS/Android: System-level sharesheet
-    /// - macOS: Save dialog
-    Future<bool> exportString(BuildContext context, String name, String data) async {
+    /// - iOS/Android: Utilizes system-level sharesheet
+    /// - macOS: Uses standard OS save dialog
+    Future<bool> export(BuildContext context, String name, List<int> data) async {
         if(Platform.isAndroid || Platform.isIOS) {
-            return _exportStringToShareSheet(context, name, data);
+            return _exportMobile(context, name, data);
         } else if(Platform.isMacOS) {
-            return _exportStringToFileSystem(name, data);
+            return _exportDesktop(name, data);
         } else {
             throw MissingPluginException('No plugin to handle exporting data is available for this platform.');
         }
     }
 
-    /// Export a given string to the OS-level share sheet with the given name.
+    /// Import a file from the filesystem.
     /// 
-    /// Temporarily writes the string as a [File] to the temporary storage directory on the OS.
+    /// Depending on the platform, uses different methods to import the data:
+    /// - iOS/Android: Utilizes `file_picker` to use mobile-OS file picker
+    /// - macOS: Uses standard OS file picker
+    Future<File> import(BuildContext context, List<String> acceptedExtensions) async {
+        if(Platform.isAndroid || Platform.isIOS) {
+            return _importMobile(context, acceptedExtensions);
+        } else if(Platform.isMacOS) {
+            return _importDesktop(acceptedExtensions);
+        } else {
+            throw MissingPluginException('No plugin to handle importing data is available for this platform.');
+        }
+    }
+
+    /// Import a file from the filesystem (mobile).
+    /// 
+    /// Allows selection of any filetype, but will check the extension of the selected file against [acceptedExtensions].
+    /// If not found in the array, or if any error occurs, will return null.
+    Future<File> _importMobile(BuildContext context, List<String> acceptedExtensions) async {
+        try {
+            FilePickerResult _file = await FilePicker.platform.pickFiles(
+                type: FileType.any,
+                allowMultiple: false,
+                allowCompression: false,
+                withData: false,
+            );
+            if(_file != null && acceptedExtensions.contains(_file.files[0].extension ?? '')) {
+                return File(_file.files[0].path);
+            }
+        } catch (error, stack) {
+            LunaLogger().error('Failed to import data from filesystem', error, stack);
+        }
+        return null;
+    }
+
+    /// Export a given byte array to the OS-level share sheet with the given name.
+    /// 
+    /// Temporarily writes the byte array as a [File] to the temporary storage directory on the OS.
     /// 
     /// Temporary storage is eventually cleared by the OS, but is more than enough time to save/send via the share sheet.
-    Future<bool> _exportStringToShareSheet(BuildContext context, String name, String data) async {
+    Future<bool> _exportMobile(BuildContext context, String name, List<int> data) async {
         try {
             final RenderBox box = context.findRenderObject();
             Directory tempDirectory = await getTemporaryDirectory();
             String path = '${tempDirectory.path}/$name';
             File file = File(path);
-            await file?.writeAsString(data);
+            await file?.writeAsBytes(data);
             await Share.shareFiles(
                 [path],
                 sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
             );
             return true;
         } catch (error, stack) {
-            LunaLogger().error('Failed to share string to sharesheet', error, stack);
+            LunaLogger().error('Failed to export data to sharesheet', error, stack);
         }
         return false;
     }
 
-    /// Export a given string to the OS-level filesystem browser with the given suggested name.
+    /// Export the given data to the OS-level filesystem save dialog with the given suggested name.
     /// 
     /// Prompts the user with a save dialog prompt with the supplied name as the recommended name.
-    Future<bool> _exportStringToFileSystem(String name, String data) async {
+    Future<bool> _exportDesktop(String name, List<int> data) async {
         try {
             String path = await FileSelectorPlatform.instance?.getSavePath(suggestedName: name);
             if(path?.isNotEmpty ?? false) {
                 File file = File(path);
-                await file?.writeAsString(data);
+                await file?.writeAsBytes(data);
                 return true;
             }
         } catch (error, stack) {
-            LunaLogger().error('Failed to share string to filesystem', error, stack);
+            LunaLogger().error('Failed to export data to filesystem', error, stack);
         }
         return false;
+    }
+
+    /// Import a file from the filesystem (Desktop).
+    /// 
+    /// Locks selection to the given [acceptedExtensions].
+    /// If any error occurs, will return null.
+    Future<File> _importDesktop(List<String> acceptedExtensions) async {
+        try {
+            final typeGroup = XTypeGroup(
+                label: 'types',
+                extensions: acceptedExtensions,
+            );
+            XFile file = await FileSelectorPlatform.instance?.openFile(acceptedTypeGroups: [typeGroup]);
+            return File(file.path);
+        } catch (error, stack) {
+            LunaLogger().error('Failed to import data from filesystem', error, stack);
+        }
+        return null;
     }
 }

--- a/lib/core/system/filesystem.dart
+++ b/lib/core/system/filesystem.dart
@@ -1,41 +1,64 @@
 import 'dart:io';
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:lunasea/core.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
 class LunaFileSystem {
+    /// Export a given string to the filesystem.
+    /// 
+    /// Depending on the platform, uses different methods to export the data:
+    /// - iOS/Android: System-level sharesheet
+    /// - macOS: Save dialog
+    Future<bool> exportString(BuildContext context, String name, String data) async {
+        if(Platform.isAndroid || Platform.isIOS) {
+            return _exportStringToShareSheet(context, name, data);
+        } else if(Platform.isMacOS) {
+            return _exportStringToFileSystem(name, data);
+        } else {
+            throw MissingPluginException('No plugin to handle exporting data is available for this platform.');
+        }
+    }
+
     /// Export a given string to the OS-level share sheet with the given name.
     /// 
     /// Temporarily writes the string as a [File] to the temporary storage directory on the OS.
     /// 
     /// Temporary storage is eventually cleared by the OS, but is more than enough time to save/send via the share sheet.
-    Future<void> exportStringToShareSheet(BuildContext context, String name, String data) async {
-        final RenderBox box = context.findRenderObject();
-        Directory tempDirectory = await getTemporaryDirectory();
-        String path = '${tempDirectory.path}/$name';
-        File file = File(path);
-        await file?.writeAsString(data);
-        await Share.shareFiles(
-            [path],
-            sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
-        ).catchError((error, stack) {
+    Future<bool> _exportStringToShareSheet(BuildContext context, String name, String data) async {
+        try {
+            final RenderBox box = context.findRenderObject();
+            Directory tempDirectory = await getTemporaryDirectory();
+            String path = '${tempDirectory.path}/$name';
+            File file = File(path);
+            await file?.writeAsString(data);
+            await Share.shareFiles(
+                [path],
+                sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
+            );
+            return true;
+        } catch (error, stack) {
             LunaLogger().error('Failed to share string to sharesheet', error, stack);
-        });
+        }
+        return false;
     }
 
-    /// Given a path to a file, shares the file to the OS-level share sheet with the given name.
+    /// Export a given string to the OS-level filesystem browser with the given suggested name.
     /// 
-    /// The path can be anywhere on the OS, but must be accessible by the application or will throw an error.
-    /// If the file does not exist, will simply do nothing.
-    Future<void> exportFileToShareSheet(BuildContext context, String path) async {
-        final RenderBox box = context.findRenderObject();
-        File file = File(path);
-        if(file.existsSync()) await Share.shareFiles(
-            [path],
-            sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
-        ).catchError((error, stack) {
-            LunaLogger().error('Failed to share file to sharesheet', error, stack);
-        });
+    /// Prompts the user with a save dialog prompt with the supplied name as the recommended name.
+    Future<bool> _exportStringToFileSystem(String name, String data) async {
+        try {
+            String path = await FileSelectorPlatform.instance?.getSavePath(suggestedName: name);
+            if(path?.isNotEmpty ?? false) {
+                File file = File(path);
+                await file?.writeAsString(data);
+                return true;
+            }
+        } catch (error, stack) {
+            LunaLogger().error('Failed to share string to filesystem', error, stack);
+        }
+        return false;
     }
 }

--- a/lib/core/utilities/logger.dart
+++ b/lib/core/utilities/logger.dart
@@ -5,7 +5,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
-import 'package:path_provider/path_provider.dart';
 
 class LunaLogger {
     static String get checkLogsMessage => 'lunasea.CheckLogsMessage'.tr();
@@ -33,7 +32,7 @@ class LunaLogger {
     }
 
     /// Export all logs, and return the [File] object containing the log file.
-    Future<File> exportLogs() async {
+    Future<String> exportLogs() async {
         // Get maps/JSON of all logs
         List<Map<String, dynamic>> logs = [];
         Database.logsBox.values.forEach((log) {
@@ -42,12 +41,7 @@ class LunaLogger {
         // Create a string
         JsonEncoder encoder = JsonEncoder.withIndent('    ');
         String data = encoder.convert(logs);
-        // Write the JSON to the temporary directory, return the file
-        Directory tempDirectory = await getTemporaryDirectory();
-        String path = '${tempDirectory.path}/logs.json';
-        File file = File(path);
-        await file?.writeAsString(data);
-        return file;
+        return data;
     }
 
     /// Clear all logs currently saved to the database.

--- a/lib/modules/nzbget/core/api/api.dart
+++ b/lib/modules/nzbget/core/api/api.dart
@@ -576,9 +576,9 @@ class NZBGetAPI {
         }
     }
 
-    Future<bool> uploadFile(String data, String name) async {
+    Future<bool> uploadFile(List<int> data, String name) async {
         try {
-            String dataBase64 = utf8.fuse(base64).encode(data);
+            String dataBase64 = base64.encode(data);
             Response response = await _dio.post(
                 '',
                 data: getBody(

--- a/lib/modules/nzbget/routes/nzbget.dart
+++ b/lib/modules/nzbget/routes/nzbget.dart
@@ -1,4 +1,4 @@
-import 'package:file_picker/file_picker.dart';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
 import 'package:lunasea/modules/nzbget.dart';
@@ -128,36 +128,22 @@ class _State extends State<NZBGet> {
 
     Future<void> _addByFile() async {
         try {
-            FilePickerResult _file = await FilePicker.platform.pickFiles(
-                type: FileType.any,
-                allowMultiple: false,
-                allowCompression: false,
-                withData: true,
-            );
-            if(_file == null) return;
-            if(
-                _file.files[0].extension == 'nzb' ||
-                _file.files[0].extension == 'zip'
-            ) {
-                String _data = String.fromCharCodes(_file.files[0].bytes);
-                String _name = _file.files[0].name;
-                if(_data != null) await _api.uploadFile(_data, _name)
+            File _file = await LunaFileSystem().import(context, ['nzb']);
+            if(_file != null) {
+                List<int> _data = _file.readAsBytesSync();
+                String _name = _file.path.substring(_file.path.lastIndexOf('/')+1);
+                if(_data?.isNotEmpty ?? false) await _api.uploadFile(_data, _name)
                 .then((value) {
                     _refreshKeys[0]?.currentState?.show();
                     showLunaSuccessSnackBar(
                         title: 'Uploaded NZB (File)',
                         message: _name,
                     );
-                })
-                .catchError((error, stack) => showLunaErrorSnackBar(
-                    title: 'Failed to Upload NZB',
-                    message: LunaLogger.checkLogsMessage,
-                    error: error,
-                ));
+                });
             } else {
                 showLunaErrorSnackBar(
                     title: 'Failed to Upload NZB',
-                    message: 'The selected file is not valid',
+                    message: 'Please select a valid file type',
                 );
             }
         } catch (error, stack) {

--- a/lib/modules/sabnzbd/core/api/api.dart
+++ b/lib/modules/sabnzbd/core/api/api.dart
@@ -514,7 +514,7 @@ class SABnzbdAPI {
         }
     }
 
-    Future<bool> uploadFile(String data, String name) async {
+    Future<bool> uploadFile(List<int> data, String name) async {
         try {
             Response response = await _dio.post(
                 '',
@@ -522,7 +522,7 @@ class SABnzbdAPI {
                     'mode': 'addfile',
                 },
                 data: FormData.fromMap({
-                    'name': MultipartFile.fromString(data, filename: name),
+                    'name': MultipartFile.fromBytes(data, filename: name),
                 }),
             );
             return response.data['status'] != null && response.data['status']

--- a/lib/modules/search/core/types/download_type.dart
+++ b/lib/modules/search/core/types/download_type.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
 import 'package:lunasea/modules/nzbget.dart';
@@ -76,7 +77,7 @@ extension SearchDownloadTypeExtension on SearchDownloadType {
         try {
             context.read<SearchState>().api.downloadRelease(data)
             .then((download) async {
-                bool result = await LunaFileSystem().exportString(context, '$cleanTitle.nzb', download);
+                bool result = await LunaFileSystem().export(context, '$cleanTitle.nzb', utf8.encode(download));
                 if(result) showLunaSuccessSnackBar(title: 'Saved NZB', message: 'NZB has been successfully saved');
             });
             

--- a/lib/modules/search/core/types/download_type.dart
+++ b/lib/modules/search/core/types/download_type.dart
@@ -75,7 +75,10 @@ extension SearchDownloadTypeExtension on SearchDownloadType {
         String cleanTitle = data.title.replaceAll(RegExp(r'[^0-9a-zA-Z. -]+'), '');
         try {
             context.read<SearchState>().api.downloadRelease(data)
-            .then((download) => LunaFileSystem().exportStringToShareSheet(context, '$cleanTitle.nzb', download));
+            .then((download) async {
+                bool result = await LunaFileSystem().exportString(context, '$cleanTitle.nzb', download);
+                if(result) showLunaSuccessSnackBar(title: 'Saved NZB', message: 'NZB has been successfully saved');
+            });
             
         } catch (error, stack) {
             LunaLogger().error('Error downloading NZB', error, stack);

--- a/lib/modules/settings/routes/system/widgets/backup_tile.dart
+++ b/lib/modules/settings/routes/system/widgets/backup_tile.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lunasea/core.dart';
@@ -23,10 +24,10 @@ class SettingsSystemBackupRestoreBackupTile extends StatelessWidget {
                 String encrypted = LunaEncryption().encrypt(_values[1], data);
                 String name = DateFormat('y-MM-dd kk-mm-ss').format(DateTime.now());
                 if(encrypted != LunaEncryption.ENCRYPTION_FAILURE) {
-                    bool result = await LunaFileSystem().exportString(
+                    bool result = await LunaFileSystem().export(
                         context,
                         '$name.lunasea',
-                        encrypted,
+                        utf8.encode(encrypted),
                     );
                     if(result) showLunaSuccessSnackBar(title: 'Saved Backup', message: 'Backup has been successfully saved');
                 }

--- a/lib/modules/settings/routes/system/widgets/backup_tile.dart
+++ b/lib/modules/settings/routes/system/widgets/backup_tile.dart
@@ -22,11 +22,14 @@ class SettingsSystemBackupRestoreBackupTile extends StatelessWidget {
                 String data = LunaConfiguration().export();
                 String encrypted = LunaEncryption().encrypt(_values[1], data);
                 String name = DateFormat('y-MM-dd kk-mm-ss').format(DateTime.now());
-                if(encrypted != LunaEncryption.ENCRYPTION_FAILURE) await LunaFileSystem().exportStringToShareSheet(
-                    context,
-                    '$name.lunasea',
-                    encrypted,
-                );
+                if(encrypted != LunaEncryption.ENCRYPTION_FAILURE) {
+                    bool result = await LunaFileSystem().exportString(
+                        context,
+                        '$name.lunasea',
+                        encrypted,
+                    );
+                    if(result) showLunaSuccessSnackBar(title: 'Saved Backup', message: 'Backup has been successfully saved');
+                }
             }
         } catch (error, stack) {
             LunaLogger().error('Backup Failed', error, stack);

--- a/lib/modules/settings/routes/system/widgets/restore_tile.dart
+++ b/lib/modules/settings/routes/system/widgets/restore_tile.dart
@@ -1,4 +1,4 @@
-import 'package:file_picker/file_picker.dart';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
 import 'package:lunasea/modules/settings.dart';
@@ -17,18 +17,9 @@ class SettingsSystemBackupRestoreRestoreTile extends StatelessWidget {
 
     Future<void> _restore(BuildContext context) async {
         try {
-            FilePickerResult _file = await FilePicker.platform.pickFiles(
-                type: FileType.any,
-                allowMultiple: false,
-                allowCompression: false,
-                withData: true,
-            );
-            if(_file == null) return;
-            if(
-                _file.files[0].extension == 'json' ||
-                _file.files[0].extension == 'lunasea'
-            ) {
-                String _data = String.fromCharCodes(_file.files[0].bytes);
+            File file = await LunaFileSystem().import(context, ['lunasea']);
+            if(file != null) {
+                String _data = file.readAsStringSync();
                 List _key = await SettingsDialogs.enterEncryptionKey(context);
                 if(_key[0]) {
                     String _decrypted = LunaEncryption().decrypt(_key[1], _data);
@@ -47,7 +38,7 @@ class SettingsSystemBackupRestoreRestoreTile extends StatelessWidget {
             } else {
                 showLunaErrorSnackBar(
                     title: 'Failed to Restore',
-                    message: 'Please select a valid backup file',
+                    message: 'Please select a valid file type',
                 );
             }
         } catch (error, stack) {

--- a/lib/modules/settings/routes/system_logs/route.dart
+++ b/lib/modules/settings/routes/system_logs/route.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
@@ -103,7 +104,7 @@ class _State extends State<_SettingsSystemLogsRoute> with LunaScrollControllerMi
                         message: 'Please wait...',
                     );
                     String data = await LunaLogger().exportLogs();
-                    bool result = await LunaFileSystem().exportString(context, 'logs.json', data);
+                    bool result = await LunaFileSystem().export(context, 'logs.json', utf8.encode(data));
                     if(result) showLunaSuccessSnackBar(title: 'Saved Logs', message: 'Logs have been successfully saved');
                 },
             ),

--- a/lib/modules/settings/routes/system_logs/route.dart
+++ b/lib/modules/settings/routes/system_logs/route.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import 'package:lunasea/core.dart';
@@ -103,8 +102,9 @@ class _State extends State<_SettingsSystemLogsRoute> with LunaScrollControllerMi
                         title: 'Exporting Logs',
                         message: 'Please wait...',
                     );
-                    File logs = await LunaLogger().exportLogs();
-                    LunaFileSystem().exportFileToShareSheet(context, logs.path);
+                    String data = await LunaLogger().exportLogs();
+                    bool result = await LunaFileSystem().exportString(context, 'logs.json', data);
+                    if(result) showLunaSuccessSnackBar(title: 'Saved Logs', message: 'Logs have been successfully saved');
                 },
             ),
         );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import cloud_firestore
 import connectivity_plus_macos
+import file_selector_macos
 import firebase_auth
 import firebase_core
 import firebase_crashlytics
@@ -23,6 +24,7 @@ import window_size
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
   - connectivity_plus_macos (0.0.1):
     - FlutterMacOS
     - Reachability
+  - file_selector_macos (0.0.1):
+    - FlutterMacOS
   - Firebase/Auth (7.7.0):
     - Firebase/CoreOnly
     - FirebaseAuth (~> 7.7.0)
@@ -137,6 +139,7 @@ PODS:
 DEPENDENCIES:
   - cloud_firestore (from `Flutter/ephemeral/.symlinks/plugins/cloud_firestore/macos`)
   - connectivity_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus_macos/macos`)
+  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - firebase_auth (from `Flutter/ephemeral/.symlinks/plugins/firebase_auth/macos`)
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
   - firebase_crashlytics (from `Flutter/ephemeral/.symlinks/plugins/firebase_crashlytics/macos`)
@@ -175,6 +178,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/cloud_firestore/macos
   connectivity_plus_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus_macos/macos
+  file_selector_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   firebase_auth:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_auth/macos
   firebase_core:
@@ -213,6 +218,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   cloud_firestore: 73379f9bfe02a98fb2caf8770c015cfb031b728a
   connectivity_plus_macos: dbac1dc9b113dfb69a5691831313b1d8ac1c8269
+  file_selector_macos: ff6dc948d4ddd34e8602a1f60b7d0b4cc6051a47
   Firebase: cd2ab85eec8170dc260186159f21072ecb679ad5
   firebase_auth: bdf6fa1a00e04c07d31149a20c069c6b8970b73f
   firebase_core: d21e840e73b38bfc0e8f1ddc8c18e0e95165e55c

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -26,8 +26,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
-		996E7A429F309CFBE66D8972 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4D84BA36AECAA069607DBD /* Pods_Runner.framework */; };
 		9CB665D62619F8E400932F8C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9CB665D52619F8E400932F8C /* GoogleService-Info.plist */; };
+		AEF7F3F008C69D5B1B9B35A3 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AB3EE95F918B84933A54A91 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,7 +54,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		29DFD9652ADB3CD2E0DEAE24 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
 		33CC10ED2044A3C60003C045 /* LunaSea.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LunaSea.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -69,12 +68,13 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
-		736C92A9F3633C41918F23E7 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		5E9E9D5F58894D6029796834 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8AB3EE95F918B84933A54A91 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		9CB665D52619F8E400932F8C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		D680F50ACBF2686222E55041 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		EC4D84BA36AECAA069607DBD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D64E24610F7ACE627CD1DC35 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		F34768B83D0109606DDF09BD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,7 +82,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				996E7A429F309CFBE66D8972 /* Pods_Runner.framework in Frameworks */,
+				AEF7F3F008C69D5B1B9B35A3 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,8 +107,8 @@
 				33FAB671232836740065AC1E /* Runner */,
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				33CC10EE2044A3C60003C045 /* Products */,
-				D73912EC22F37F3D000D13A0 /* Frameworks */,
 				C16DBC6D5885D252E3ED5BAD /* Pods */,
+				EDB604BB3D2BCFFA438AD21A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -158,17 +158,17 @@
 		C16DBC6D5885D252E3ED5BAD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				29DFD9652ADB3CD2E0DEAE24 /* Pods-Runner.debug.xcconfig */,
-				736C92A9F3633C41918F23E7 /* Pods-Runner.release.xcconfig */,
-				D680F50ACBF2686222E55041 /* Pods-Runner.profile.xcconfig */,
+				F34768B83D0109606DDF09BD /* Pods-Runner.debug.xcconfig */,
+				5E9E9D5F58894D6029796834 /* Pods-Runner.release.xcconfig */,
+				D64E24610F7ACE627CD1DC35 /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
+		EDB604BB3D2BCFFA438AD21A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				EC4D84BA36AECAA069607DBD /* Pods_Runner.framework */,
+				8AB3EE95F918B84933A54A91 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -180,14 +180,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				7517236C46401D88661093C3 /* [CP] Check Pods Manifest.lock */,
+				3E6C47D81A785C2DC77779BB /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				4C7113F69C871E3EAB4D0D5B /* [CP] Embed Pods Frameworks */,
-				9A73E994811AE97876F10DFC /* [CP] Copy Pods Resources */,
+				F53D3BDBE11A434D18A01B9D /* [CP] Embed Pods Frameworks */,
+				D7597EFDDC7C3F148CE212AB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -295,24 +295,7 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
-		4C7113F69C871E3EAB4D0D5B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7517236C46401D88661093C3 /* [CP] Check Pods Manifest.lock */ = {
+		3E6C47D81A785C2DC77779BB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -334,7 +317,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9A73E994811AE97876F10DFC /* [CP] Copy Pods Resources */ = {
+		D7597EFDDC7C3F148CE212AB /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -349,6 +332,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F53D3BDBE11A434D18A01B9D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1+1"
   crypto:
     dependency: transitive
     description:
@@ -309,6 +316,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  file_selector_macos:
+    dependency: "direct main"
+    description:
+      name: file_selector_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
+  file_selector_platform_interface:
+    dependency: "direct main"
+    description:
+      name: file_selector_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   firebase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
   encrypt: ^5.0.0                         # ANDROID IOS LINUX MACOS WEB WINDOWS
   expandable: ^5.0.1                      # ANDROID IOS LINUX MACOS WEB WINDOWS
   file_picker: ^3.0.1                     # ANDROID IOS             WEB
+  file_selector_macos: ^0.0.4             #                   MACOS
+  file_selector_platform_interface: ^2.0.2 # ANDROID IOS LINUX MACOS WEB WINDOWS
   firebase_analytics: ^8.0.0              # ANDROID IOS             WEB
   firebase_auth: ^1.1.0                   # ANDROID IOS       MACOS WEB
   firebase_core: ^1.0.3                   # ANDROID IOS       MACOS WEB


### PR DESCRIPTION
All filesystem calls on macOS (importing/exporting backups, downloading NZBs, etc.) will now use macOS-native filesystem dialogs to save and select files.

Fixes #413 #418 