### PR TITLE
chore(release): v5.0.0+50000018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### FIXES
 - `[Dashboard]` (Calendar) Stored current date would not update on date change
+- `[Drawer]` Drawer could show a grey screen in some instances
 
 #### PLATFORM-SPECIFIC
 - `[macOS]` (fix) Utilize native filesystem dialogs for selecting and saving files

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,104 +1,34 @@
 {
-    "motd": "This build introduces the public/beta release of webhook-based push notifications for LunaSea! Push notifications are supported on all 3 platforms (Android, iOS, and macOS) and are completely free. Want push notifications from your modules sent to LunaSea? Head to the Settings' notification page to get started! \n\nThis build also includes some other minor changes including an option to set the Radarr queue page size, refreshing Sonarr's queue will now also refresh the download client status, and it is now easier to dismiss bottom sheets by swiping down.",
-    "new": [
-        {
-            "module": "Notifications",
-            "changes": [
-                "Release webhook-based notifications to all beta users"
-            ]
-        },
-        {
-            "module": "Settings",
-            "changes": [
-                "Added localization configuration page",
-                "Added setup page for webhook notifications",
-                "(Radarr) Added option to set queue page size"
-            ]
-        },
-        {
-            "module": "Sonarr",
-            "changes": [
-                "(Queue) Refreshing the queue will now also refresh the monitored downloads from the clients"
-            ]
-        }
-    ],
+    "motd": "We're nearing the stable release of v5.0.0, so the last remaining builds will just include minor tweaks and fixes! his release is the first release candidate, so no more large changes will occur.",
+    "new": [],
     "tweaks": [
         {
-            "module": "Notifications",
+            "module": "Dashboard",
             "changes": [
-                "(Radarr) Now opens the queue on \"Grab\" notifications",
-                "(Sonarr) Now opens the queue on \"Grab\" notifications"
-            ]
-        },
-        {
-            "module": "Radarr",
-            "changes": [
-                "(Queue) Increased default queue page size to 50 items"
-            ]
-        },
-        {
-            "module": "Settings",
-            "changes": [
-                "(Account) Removed the ability to pull user ID or device ID from help dialog"
+                "(Calendar) Set bounds to calendar",
+                "(Calendar) Made the styling for calendar slightly more consistent"
             ]
         }
     ],
     "fixes": [
         {
-            "module": "Bottom Sheet",
+            "module": "Dashboard",
             "changes": [
-                "Reduce swipe down to dismiss threshold to 10% of height"
+                "(Calendar) Stored current date would not update on date change"
             ]
         },
         {
-            "module": "Firebase",
+            "module": "Drawer",
             "changes": [
-                "Add platform check to disable Firebase on incompatible platforms"
-            ]
-        },
-        {
-            "module": "Flutter",
-            "changes": [
-                "Update packages"
-            ]
-        },
-        {
-            "module": "Radarr",
-            "changes": [
-                "(File Details) Show a dash when no information is available for a table entry"
-            ]
-        },
-        {
-            "module": "Sonarr",
-            "changes": [
-                "(Queue) Ensure the trailing icon on queue entries is centered vertically"
-            ]
-        },
-        {
-            "module": "UI/UX",
-            "changes": [
-                "Add padding around \"No Tags Found\" message within tag selection dialogs",
-                "Improve consistency of module-level settings dialog"
+                "Drawer could show a grey screen in some instances"
             ]
         }
     ],
     "platform": [
         {
-            "module": "Android",
-            "changes": [
-                "(new) Attach module headers to requests when viewing the web GUI"
-            ]
-        },
-        {
             "module": "macOS",
             "changes": [
-                "(fix) Sharesheet would not appear on iPadOS devices"
-            ]
-        },
-        {
-            "module": "macOS",
-            "changes": [
-                "(fix) Sharesheet now supports macOS builds"
+                "(fix) Utilize native filesystem dialogs for selecting and saving files"
             ]
         }
     ]

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,5 +1,5 @@
 {
-    "motd": "We're nearing the stable release of v5.0.0, so the last remaining builds will just include minor tweaks and fixes! his release is the first release candidate, so no more large changes will occur.",
+    "motd": "We're nearing the stable release of v5.0.0, so the last remaining builds will just include minor tweaks and fixes! This build is the first release candidate, so no more large changes will occur.",
     "new": [],
     "tweaks": [
         {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lunasea
 description: Self-Hosted Controller
-version: 5.0.0+50000017
+version: 5.0.0+50000018
 publish_to: 'none'
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
#### TWEAKS
- `[Dashboard]` (Calendar) Set bounds to calendar
- `[Dashboard]` (Calendar) Made the styling for calendar slightly more consistent

#### FIXES
- `[Dashboard]` (Calendar) Stored current date would not update on date change
- `[Drawer]` Drawer could show a grey screen in some instances

#### PLATFORM-SPECIFIC
- `[macOS]` (fix) Utilize native filesystem dialogs for selecting and saving files