### PR TITLE
chore(release): v5.1.0+50100002

### DIFF
--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,76 +1,39 @@
 {
-    "motd": "Welcome to the first build of v5.1.0 of LunaSea!\n\nThis build introduces a new feature to customize the order of modules in your drawer! Head to the settings to customize your ordering, or stick to the automatically managed ordering, which simply sorts modules alphabetically. The dashboard and settings options are static and can not be removed or reordered.\n\nThis build also introduces some fixes, including indexer search not opening for some users and setting the date formatter to match LunaSea's set language. Please note that this is a temporary regression for users with non-English languages set on their device while LunaSea only supports English, but will be reintroduced once LunaSea has full support for localizations!",
-    "new": [
-        {
-            "module": "Dashboard",
-            "changes": [
-                "(Modules) Show Wake on LAN tile"
-            ]
-        },
-        {
-            "module": "Drawer",
-            "changes": [
-                "Ability to customize the order of modules"
-            ]
-        }
-    ],
+    "motd": "This build fixes some bugs and makes some minor polishes to the user interface.",
+    "new": [],
     "tweaks": [
         {
             "module": "Dashboard",
             "changes": [
-                "(Modules) Synchronize module ordering with drawer ordering"
-            ]
-        },
-        {
-            "module": "Drawer",
-            "changes": [
-                "Default to sorting modules alphabetically"
-            ]
-        },
-        {
-            "module": "Dashboard",
-            "changes": [
-                "(Configuration) Alphabetically sort the modules"
-            ]
-        }
-    ],
-    "fixes": [
-        {
-            "module": "Flutter",
-            "changes": [
-                "Updated packages",
-                "Upgrade to Firebase SDK v7.11.0"
-            ]
-        },
-        {
-            "module": "Locale",
-            "changes": [
-                "Ensure that the date formatter uses the currently set locale"
-            ]
-        },
-        {
-            "module": "Search",
-            "changes": [
-                "Indexers would not load in some cases when the headers map was null/empty"
+                "(Calendar) Add divider between calendar and calendar entries"
             ]
         },
         {
             "module": "Settings",
             "changes": [
-                "(Connection Test) Connection tests could fail unexpectedly"
+                "(Configuration) Add divider between automatic toggle and manual order list"
+            ]
+        }
+    ],
+    "fixes": [
+        {
+            "module": "Backup & Restore",
+            "changes": [
+                "Backup would fail when the drawer order is not configured"
             ]
         },
         {
-            "module": "Sonarr",
+            "module": "Settings",
             "changes": [
-                "(Edit) Grey screen could be shown when a user has no tags",
-                "(Edit) Grey screen could be shown when a user has no language profiles"
+                "(Configuration) Drawer customization page would not pad for safe areas",
+                "(Dialogs) Ensure all bulleted lists in dialogs are left aligned"
             ]
         },
         {
             "module": "UI/UX",
             "changes": [
-                "Popup menus were not aligned correctly"
+                "(Buttons) Border would incorrectly be applied to buttons with a background colour set",
+                "(Refresh Indicator) Indicator colour was incorrect"
             ]
         }
     ],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -27,7 +27,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
-  FLTPackageInfoPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.0.0"
+    version: "21.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   archive:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   badges:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   build_config:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.4"
+    version: "8.0.5"
   characters:
     dependency: transitive
     description:
@@ -203,7 +203,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   dio:
     dependency: "direct main"
     description:
@@ -465,7 +465,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7+1"
+    version: "1.1.8+4"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -498,7 +498,7 @@ packages:
       name: google_nav_bar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.4"
+    version: "5.0.5"
   graphs:
     dependency: transitive
     description:
@@ -533,14 +533,14 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1"
+    version: "0.13.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
@@ -659,42 +659,42 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   package_info_plus_linux:
     dependency: transitive
     description:
       name: package_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   package_info_plus_macos:
     dependency: transitive
     description:
       name: package_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   package_info_plus_web:
     dependency: transitive
     description:
       name: package_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   package_info_plus_windows:
     dependency: transitive
     description:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   path:
     dependency: transitive
     description:
@@ -736,7 +736,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   pedantic:
     dependency: transitive
     description:
@@ -848,42 +848,42 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   share_plus_linux:
     dependency: transitive
     description:
       name: share_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   share_plus_macos:
     dependency: transitive
     description:
       name: share_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   share_plus_web:
     dependency: transitive
     description:
       name: share_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   share_plus_windows:
     dependency: transitive
     description:
       name: share_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   shared_preferences:
     dependency: transitive
     description:
@@ -932,7 +932,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -958,7 +958,7 @@ packages:
       name: sliver_tools
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   sonarr:
     dependency: "direct main"
     description:
@@ -1071,6 +1071,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lunasea
 description: Self-Hosted Controller
-version: 5.1.0+50100001
+version: 5.1.0+50100002
 publish_to: 'none'
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -31,7 +31,7 @@ dependencies:
   fl_chart: ^0.35.0                         # ANDROID IOS LINUX MACOS WEB WINDOWS
   # font_awesome_flutter:                   # ANDROID IOS LINUX MACOS WEB WINDOWS
   #   path: vendor/font_awesome_flutter
-  google_nav_bar: ^5.0.4                    # ANDROID IOS LINUX MACOS WEB WINDOWS
+  google_nav_bar: ^5.0.5                    # ANDROID IOS LINUX MACOS WEB WINDOWS
   hive: ^2.0.4                              # ANDROID IOS LINUX MACOS WEB WINDOWS
   hive_flutter: ^1.0.0                      # ANDROID IOS LINUX MACOS     WINDOWS
   in_app_purchase: ^0.5.2                   # ANDROID IOS
@@ -39,13 +39,13 @@ dependencies:
   intl: ^0.17.0                             # ANDROID IOS LINUX MACOS WEB WINDOWS
   modal_bottom_sheet: ^2.0.0                # ANDROID IOS LINUX MACOS WEB WINDOWS
   overseerr: ^0.0.1-pre.5                   # ANDROID IOS LINUX MACOS WEB WINDOWS
-  package_info_plus: ^1.0.0                 # ANDROID IOS LINUX MACOS WEB WINDOWS
+  package_info_plus: ^1.0.1                 # ANDROID IOS LINUX MACOS WEB WINDOWS
   path_provider: ^2.0.1                     # ANDROID IOS LINUX MACOS     WINDOWS
   percent_indicator: ^3.0.1                 # ANDROID IOS LINUX MACOS WEB WINDOWS
   provider: ^5.0.0                          # ANDROID IOS LINUX MACOS WEB WINDOWS
   quick_actions: ^0.6.0+1                   # ANDROID IOS
   radarr: ^2.1.0                            # ANDROID IOS LINUX MACOS WEB WINDOWS
-  share_plus: ^2.0.2                        # ANDROID IOS LINUX MACOS WEB WINDOWS
+  share_plus: ^2.0.3                        # ANDROID IOS LINUX MACOS WEB WINDOWS
   sonarr: ^2.0.1                            # ANDROID IOS LINUX MACOS WEB WINDOWS
   stack_trace: ^1.10.0                      # ANDROID IOS LINUX MACOS WEB WINDOWS
   supercharged: ^2.0.0                      # ANDROID IOS LINUX MACOS WEB WINDOWS
@@ -65,7 +65,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.12.2
   flutter_launcher_icons: ^0.9.0
-  flutter_native_splash: ^1.1.7+1
+  flutter_native_splash: ^1.1.8+4
   hive_generator: ^1.1.0
 
 flutter:


### PR DESCRIPTION
#### TWEAKS

- `[Dashboard]` (Calendar) Add divider between calendar and calendar entries
- `[Settings]` (Configuration) Add divider between automatic toggle and manual order list

#### FIXES

- `[Backup & Restore]` Backup would fail when the drawer order is not configured
- `[Settings]` (Configuration) Drawer customization page would not pad for safe areas
- `[Settings]` (Dialogs) Ensure all bulleted lists in dialogs are left aligned
- `[UI/UX]` (Buttons) Border would incorrectly be applied to buttons with a background colour set
- `[UI/UX]` (Refresh Indicator) Indicator colour was incorrect