### PR TITLE
chore(release): v5.1.0+50100004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,67 +2,35 @@
 
 ## v5.1.0 (50100004)
 
-#### FIXES
-
-- `[Radarr]` (Manual Import) Could not select movie when using Radarr v3.1.0+
-- `[Tautulli]` (Graphs) Line chart tooltips had incorrect data
-
----
-
-## v5.1.0 (50100003)
-
-#### NEW
-
-- `[External Modules]` Ability to add and view external modules
-- `[Flutter]` Build LunaSea with precompiled SkSL shaders
-
-#### FIXES
-
-- `[Flutter]` Update packages
-- `[UI/UX]` (ListView) Vertical padding did not match horizontal padding
-
----
-
-## v5.1.0 (50100002)
-
-#### TWEAKS
-
-- `[Dashboard]` (Calendar) Add divider between calendar and calendar entries
-- `[Settings]` (Configuration) Add divider between automatic toggle and manual order list
-
-#### FIXES
-
-- `[Backup & Restore]` Backup would fail when the drawer order is not configured
-- `[Settings]` (Configuration) Drawer customization page would not pad for safe areas
-- `[Settings]` (Dialogs) Ensure all bulleted lists in dialogs are left aligned
-- `[UI/UX]` (Buttons) Border would incorrectly be applied to buttons with a background colour set
-- `[UI/UX]` (Refresh Indicator) Indicator colour was incorrect
-
----
-
-## v5.1.0 (50100001)
-
 #### NEW
 
 - `[Dashboard]` (Modules) Show Wake on LAN tile
 - `[Drawer]` Ability to customize the order of modules
+- `[External Modules]` Ability to add and view external modules
+- `[Performance]` Build LunaSea with precompiled SkSL shaders
 
 #### TWEAKS
 
+- `[Dashboard]` (Calendar) Add divider between calendar and calendar entries
 - `[Dashboard]` (Modules) Synchronize module ordering with drawer ordering
 - `[Drawer]` Default to sorting modules alphabetically
 - `[Settings]` (Configuration) Alphabetically sort the modules
 
 #### FIXES
 
-- `[Flutter]` Updated packages
+- `[Flutter]` Update packages
 - `[Flutter]` Upgrade to Firebase SDK v7.11.0
 - `[Locale]` Ensure that the date formatter uses the currently set locale
+- `[Radarr]` (Manual Import) Could not select movie when using Radarr v3.1.0+
 - `[Search]` Indexers would not load in some cases when the headers map was null/empty
 - `[Settings]` (Connection Test) Connection tests could fail unexpectedly
+- `[Settings]` (Dialogs) Ensure all bulleted lists in dialogs are left aligned
 - `[Sonarr]` (Edit) Grey screen could be shown when a user has no tags
 - `[Sonarr]` (Edit) Grey screen could be shown when a user has no language profiles
+- `[Tautulli]` (Graphs) Line chart tooltips had incorrect data
 - `[UI/UX]` Popup menus were not aligned correctly
+- `[UI/UX]` (Buttons) Border would incorrectly be applied to buttons with a background colour set
+- `[UI/UX]` (ListView) Vertical padding did not match horizontal padding
 
 ---
 

--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,7 +1,18 @@
 {
-    "motd": "This build introduces a new pseudo-module, the ability to add external modules! You can now add references to the web GUI for modules that are not supported by LunaSea to quickly and easily access their web GUIs from within LunaSea.\n\nThis build also introduces the first build for LunaSea to use precompiled SkSL shaders! LunaSea will no longer need to compile graphical shaders on-the-fly, and should have a noticeable performance boost especially on a cold start of LunaSea.",
-    "new": [],
-    "tweaks": [
+    "motd": "Welcome to LunaSea v5.1.0!\n\nThis update introduces a new pseudo-module, the ability to add external modules to LunaSea! Adding external modules to LunaSea allows you to quickly and easily jump to the web GUI for modules that are currently not supported by LunaSea, keeping all of your management needs in one place.\n\nThis update also introduces a new customization feature, the ability to reorder your drawer! The drawer and dashboard modules list now default to being sorted alphabetically, but jump into the settings to pick the order you like.\n\nFinally, alongside other minor fixes and tweaks, this update now includes pre-compiled SkSL graphical shaders! This means you should now experience less \"jank\" within LunaSea, especially on a cold-start.",
+    "new": [
+        {
+            "module": "Dashboard",
+            "changes": [
+                "(Modules) Show Wake on LAN tile"
+            ]
+        },
+        {
+            "module": "Drawer",
+            "changes": [
+                "Ability to customize the order of modules"
+            ]
+        },
         {
             "module": "External Modules",
             "changes": [
@@ -15,16 +26,78 @@
             ]
         }
     ],
+    "tweaks": [
+        {
+            "module": "Dashboard",
+            "changes": [
+                "(Calendar) Add divider between calendar and calendar entries",
+                "(Modules) Synchronize module ordering with drawer ordering"
+            ]
+        },
+        {
+            "module": "Drawer",
+            "changes": [
+                "Default to sorting modules alphabetically"
+            ]
+        },
+        {
+            "module": "Settings",
+            "changes": [
+                "(Configuration) Alphabetically sort the modules"
+            ]
+        }
+    ],
     "fixes": [
         {
             "module": "Flutter",
             "changes": [
-                "Update packages"
+                "Update packages",
+                "Upgrade to Firebase SDK v7.11.0"
+            ]
+        },
+        {
+            "module": "Locale",
+            "changes": [
+                "Ensure that the date formatter uses the currently set locale"
+            ]
+        },
+        {
+            "module": "Radarr",
+            "changes": [
+                "(Manual Import) Could not select movie when using Radarr v3.1.0+"
+            ]
+        },
+        {
+            "module": "Search",
+            "changes": [
+                "Indexers would not load in some cases when the headers map was null/empty"
+            ]
+        },
+        {
+            "module": "Settings",
+            "changes": [
+                "(Connection Test) Connection tests could fail unexpectedly",
+                "(Dialogs) Ensure all bulleted lists in dialogs are left aligned"
+            ]
+        },
+        {
+            "module": "Sonarr",
+            "changes": [
+                "(Edit) Grey screen could be shown when a user has no tags",
+                "(Edit) Grey screen could be shown when a user has no language profiles"
+            ]
+        },
+        {
+            "module": "Tautulli",
+            "changes": [
+                "(Graphs) Line chart tooltips had incorrect data"
             ]
         },
         {
             "module": "UI/UX",
             "changes": [
+                "Popup menus were not aligned correctly",
+                "(Buttons) Border would incorrectly be applied to buttons with a background colour set",
                 "(ListView) Vertical padding did not match horizontal padding"
             ]
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lunasea
 description: Self-Hosted Controller
-version: 5.1.0+50100003
+version: 5.1.0+50100004
 publish_to: 'none'
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
#### NEW

- `[Dashboard]` (Modules) Show Wake on LAN tile
- `[Drawer]` Ability to customize the order of modules
- `[External Modules]` Ability to add and view external modules
- `[Performance]` Build LunaSea with precompiled SkSL shaders

#### TWEAKS

- `[Dashboard]` (Calendar) Add divider between calendar and calendar entries
- `[Dashboard]` (Modules) Synchronize module ordering with drawer ordering
- `[Drawer]` Default to sorting modules alphabetically
- `[Settings]` (Configuration) Alphabetically sort the modules

#### FIXES

- `[Flutter]` Update packages
- `[Flutter]` Upgrade to Firebase SDK v7.11.0
- `[Locale]` Ensure that the date formatter uses the currently set locale
- `[Radarr]` (Manual Import) Could not select movie when using Radarr v3.1.0+
- `[Search]` Indexers would not load in some cases when the headers map was null/empty
- `[Settings]` (Connection Test) Connection tests could fail unexpectedly
- `[Settings]` (Dialogs) Ensure all bulleted lists in dialogs are left aligned
- `[Sonarr]` (Edit) Grey screen could be shown when a user has no tags
- `[Sonarr]` (Edit) Grey screen could be shown when a user has no language profiles
- `[Tautulli]` (Graphs) Line chart tooltips had incorrect data
- `[UI/UX]` Popup menus were not aligned correctly
- `[UI/UX]` (Buttons) Border would incorrectly be applied to buttons with a background colour set
- `[UI/UX]` (ListView) Vertical padding did not match horizontal padding
