### PR TITLE
Use Sonarr v3 API endpoint for mediacovers

### DIFF
--- a/lib/modules/sonarr/core/state.dart
+++ b/lib/modules/sonarr/core/state.dart
@@ -266,8 +266,8 @@ class SonarrState extends LunaModuleState {
 
   String _baseImageURL() {
     return _host.endsWith('/')
-        ? '${_host}api/MediaCover'
-        : '$_host/api/MediaCover';
+        ? '${_host}api/v3/MediaCover'
+        : '$_host/api/v3/MediaCover';
   }
 
   String getBannerURL(int seriesId, {bool highRes = false}) {


### PR DESCRIPTION
Use v3 endpoints for mediacovers like we do for all other endpoints

Brings Sonarr in line with Radarr
https://github.com/CometTools/LunaSea/blob/b4945c0f69e191702b2303a0a7b7f90c6bc11b71/lib/modules/radarr/core/state.dart#L329-L332

Fixes #521 