### PR TITLE
chore(build): rename Android debug build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,6 +65,10 @@ android {
    }
    
    buildTypes {
+       debug {
+           applicationIdSuffix ".debug"
+           versionNameSuffix "-dev"
+       }
        release {
            signingConfig signingConfigs.release
        }


### PR DESCRIPTION
This allows to install the debug version without conflicting with the release version